### PR TITLE
Add Lampinen tests for differential_evolution

### DIFF
--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -757,8 +757,50 @@ class TestDifferentialEvolutionSolver(object):
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))
 
+    def test_L3(self):
+        # Lampinen ([5]) test problem 3
+
+        def f(x):
+            x = np.hstack(([0], x))  # 1-indexed to match reference
+            fun = (x[1]**2 + x[2]**2 + x[1]*x[2] - 14*x[1] - 16*x[2] +
+                   (x[3]-10)**2 + 4*(x[4]-5)**2 + (x[5]-3)**2 + 2*(x[6]-1)**2 +
+                   5*x[7]**2 + 7*(x[8]-11)**2 + 2*(x[9]-10)**2 +
+                   (x[10] - 7)**2 + 45
+                   )
+            return fun  # maximize
+
+        A = np.zeros((4, 11))
+        A[1, [1, 2, 7, 8]] = -4, -5, 3, -9
+        A[2, [1, 2, 7, 8]] = -10, 8, 17, -2
+        A[3, [1, 2, 9, 10]] = 8, -2, -5, 2
+        A = A[1:, 1:]
+        b = np.array([-105, 0, -12])
+
+        def c1(x):
+            x = np.hstack(([0], x))  # 1-indexed to match reference
+            return [3*x[1] - 6*x[2] - 12*(x[9]-8)**2 + 7*x[10],
+                    -3*(x[1]-2)**2 - 4*(x[2]-3)**2 - 2*x[3]**2 + 7*x[4] + 120,
+                    -x[1]**2 - 2*(x[2]-2)**2 + 2*x[1]*x[2] - 14*x[5] + 6*x[6],
+                    -5*x[1]**2 - 8*x[2] - (x[3]-6)**2 + 2*x[4] + 40,
+                    -0.5*(x[1]-8)**2 - 2*(x[2]-4)**2 - 3*x[5]**2 + x[6] + 30]
+
+        L = LinearConstraint(A, b, np.inf)
+        N = NonlinearConstraint(c1, 0, np.inf)
+        bounds = [(-10, 10)]*10
+        constraints = (L, N)
+        res = differential_evolution(f, bounds, maxiter=5000, popsize=35, mutation=0.9, recombination=0.9, constraints=constraints)
+        x_opt = (2.171996, 2.363683, 8.773926, 5.095984, 0.990654,
+                 1.430574, 1.321644, 9.828726, 8.280092, 8.375927)
+        f_opt = 24.3062091
+        assert_allclose(res.x, x_opt, atol=0.2, rtol=0.2)
+        assert_allclose(res.fun, f_opt, atol=0.5, rtol=0.05)
+        assert_(np.all(A @ res.x >= b))
+        assert_(np.all(np.array(c1(res.x)) >= 0))
+        assert_(np.all(res.x >= np.array(bounds)[:, 0]))
+        assert_(np.all(res.x <= np.array(bounds)[:, 1]))
+
     def test_L5(self):
-        # Lampinen ([5]) test problem 2
+        # Lampinen ([5]) test problem 5
 
         def f(x):
             x = np.hstack(([0], x))  # 1-indexed to match reference

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -921,6 +921,44 @@ class TestDifferentialEvolutionSolver(object):
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))
 
+    def test_L8(self):
+        def f(x):
+            x = np.hstack(([0], x))  # 1-indexed to match reference
+            fun = 3*x[1] + 0.000001*x[1]**3 + 2*x[2] + 0.000002/3*x[2]**3
+            return fun
+
+        A = np.zeros((3, 5))
+        A[1, [4, 3]] = 1, -1
+        A[2, [3, 4]] = 1, -1
+        A = A[1:, 1:]
+        b = np.array([-.55, -.55])
+
+        def c1(x):
+            x = np.hstack(([0], x))  # 1-indexed to match reference
+            return [
+                    1000*np.sin(-x[3]-0.25) + 1000*np.sin(-x[4]-0.25) + 894.8 - x[1],
+                    1000*np.sin(x[3]-0.25) + 1000*np.sin(x[3]-x[4]-0.25) + 894.8 - x[2],
+                    1000*np.sin(x[4]-0.25) + 1000*np.sin(x[4]-x[3]-0.25) + 1294.8
+                    ]
+        L = LinearConstraint(A, b, np.inf)
+        N = NonlinearConstraint(c1, -0.001*np.ones(3), 0.001*np.ones(3))
+
+        bounds = [(0, 1200)]*2+[(-.55, .55)]*2
+        constraints = (L, N)
+        res = differential_evolution(f, bounds, maxiter=10000, popsize=120,
+                                     mutation=0.9, recombination=0.9,
+                                     constraints=constraints)
+        x_opt = (679.9453, 1026.067, 0.1188764, -0.3962336)
+        f_opt = 5126.4981
+        assert_allclose(res.x[:2], x_opt[:2], atol=1)
+        assert_allclose(res.x[2:], x_opt[2:], atol=0.001)
+        assert_allclose(res.fun, f_opt, atol=0.1)
+        assert_(np.all(A@res.x >= b))
+        assert_(np.all(np.array(c1(res.x)) >= -0.001))
+        assert_(np.all(np.array(c1(res.x)) <= 0.001))
+        assert_(np.all(res.x >= np.array(bounds)[:, 0]))
+        assert_(np.all(res.x <= np.array(bounds)[:, 1]))
+
     def test_L9(self):
         # Lampinen ([5]) test problem 9
 

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -6,7 +6,8 @@ import multiprocessing
 from scipy.optimize import _differentialevolution
 from scipy.optimize._differentialevolution import DifferentialEvolutionSolver
 from scipy.optimize import differential_evolution, minimize
-from scipy.optimize._constraints import Bounds, NonlinearConstraint
+from scipy.optimize._constraints import (Bounds, NonlinearConstraint,
+                                         LinearConstraint)
 from scipy.optimize import rosen
 
 import numpy as np
@@ -666,3 +667,42 @@ class TestDifferentialEvolutionSolver(object):
                   1.0, False, np.array([1., 0.50])))
         assert (fn(1.0, False, np.array([0.5, 0.5]),
                   1.0, False, np.array([1., 0.4])) == False)
+
+    def test_L1(self):
+        # Lampinen ([5]) test problem 1
+
+        def f(x):
+            temp = x
+            x = np.zeros(14)
+            x[1:] = temp  # 1-indexed to match reference
+            fun = np.sum(5*x[1:5]) - 5*x[1:5]@x[1:5] - np.sum(x[5:])
+            return fun
+
+        A = np.zeros((10, 14))  # 1-indexed to match reference
+        A[1, [1, 2, 10, 11]] = 2, 2, 1, 1
+        A[2, [1, 10]] = -8, 1
+        A[3, [4, 5, 10]] = -2, -1, 1
+        A[4, [1, 3, 10, 11]] = 2, 2, 1, 1
+        A[5, [2, 11]] = -8, 1
+        A[6, [6, 7, 11]] = -2, -1, 1
+        A[7, [2, 3, 11, 12]] = 2, 2, 1, 1
+        A[8, [3, 12]] = -8, 1
+        A[9, [8, 9, 12]] = -2, -1, 1
+        A = A[1:, 1:]
+
+        b = np.array([10, 0, 0, 10, 0, 0, 10, 0, 0])
+
+        L = LinearConstraint(A, -np.inf, b)
+
+        bounds = [(0, 1)]*9 + [(0, 100)]*3 + [(0, 1)]
+
+        # using parameters from [5]
+        res = differential_evolution(f, bounds, maxiter=4000, popsize=20,
+                                     mutation=0.9, recombination=0.9,
+                                     constraints=(L))
+
+        x_opt = (1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 1)
+        f_opt = -15
+
+        assert_allclose(res.x, x_opt, atol=1e-1, rtol=1e-1)
+        assert_allclose(res.fun, f_opt, atol=3e-2, rtol=3e-2)

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -702,8 +702,8 @@ class TestDifferentialEvolutionSolver(object):
         x_opt = (1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 1)
         f_opt = -15
 
-        assert_allclose(res.x, x_opt, atol=1e-1, rtol=1e-1)
-        assert_allclose(res.fun, f_opt, atol=3e-2, rtol=3e-2)
+        assert_allclose(res.x, x_opt, atol=1e-1)
+        assert_allclose(res.fun, f_opt, atol=0.5)
         assert_(np.all(A@res.x <= b))
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))
@@ -724,8 +724,11 @@ class TestDifferentialEvolutionSolver(object):
         constraints = (L, N, L2, N2)
         res = differential_evolution(f, bounds, constraints=constraints)
 
-        assert_allclose(res.x, x_opt, atol=1e-1, rtol=1e-1)
-        assert_allclose(res.fun, f_opt, atol=3e-2, rtol=3e-2)
+        assert_allclose(res.x, x_opt, atol=1e-1)
+        assert_allclose(res.fun, f_opt, atol=0.5)
+        assert_(np.all(A@res.x <= b))
+        assert_(np.all(res.x >= np.array(bounds)[:, 0]))
+        assert_(np.all(res.x <= np.array(bounds)[:, 1]))
 
     def test_L2(self):
         # Lampinen ([5]) test problem 2
@@ -752,7 +755,7 @@ class TestDifferentialEvolutionSolver(object):
                                      constraints=constraints)
 
         f_opt = 680.6300599487869
-        assert_allclose(res.fun, f_opt, atol=5, rtol=1e-2)
+        assert_allclose(res.fun, f_opt, atol=5)
         assert_(np.all(np.array(c1(res.x)) >= 0))
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))
@@ -792,8 +795,8 @@ class TestDifferentialEvolutionSolver(object):
         x_opt = (2.171996, 2.363683, 8.773926, 5.095984, 0.990654,
                  1.430574, 1.321644, 9.828726, 8.280092, 8.375927)
         f_opt = 24.3062091
-        assert_allclose(res.x, x_opt, atol=0.2, rtol=0.2)
-        assert_allclose(res.fun, f_opt, atol=0.5, rtol=0.05)
+        assert_allclose(res.x, x_opt, atol=0.2)
+        assert_allclose(res.fun, f_opt, atol=0.5)
         assert_(np.all(A @ res.x >= b))
         assert_(np.all(np.array(c1(res.x)) >= 0))
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
@@ -826,7 +829,7 @@ class TestDifferentialEvolutionSolver(object):
                                      mutation=0.9, recombination=0.9,
                                      constraints=constraints)
 
-        assert_allclose(res.fun, f_opt, atol=50, rtol=1)
+        assert_allclose(res.fun, f_opt, atol=75)
         assert_(np.all(A @ res.x <= b))
         assert_(np.all(np.array(c1(res.x)) >= 0))
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
@@ -854,8 +857,8 @@ class TestDifferentialEvolutionSolver(object):
                                      constraints=constraints)
         x_opt = (1.22067691, 4.24096915)
         f_opt = -0.10077999749728803
-        assert_allclose(res.x, x_opt, atol=1e-2, rtol=1e-2)
-        assert_allclose(res.fun, f_opt, atol=1e-4, rtol=1e-3)
+        assert_allclose(res.x, x_opt, atol=1e-2)
+        assert_allclose(res.fun, f_opt, atol=1e-4)
         assert_(np.all(np.array(c1(res.x)) <= 0))
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))
@@ -880,8 +883,8 @@ class TestDifferentialEvolutionSolver(object):
                                      constraints=constraints)
         x_opt = (14.095, 0.84296)
         f_opt = -6961.81381
-        assert_allclose(res.x, x_opt, atol=1e-1, rtol=1e-1)
-        assert_allclose(res.fun, f_opt, atol=75, rtol=.01)
+        assert_allclose(res.x, x_opt, atol=1e-1)
+        assert_allclose(res.fun, f_opt, atol=75)
         assert_(np.all(np.array(c1(res.x)) >= 0))
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))
@@ -893,7 +896,6 @@ class TestDifferentialEvolutionSolver(object):
             fun = (5.3578547*x[3]**2 + 0.8356891*x[1]*x[5] +
                    37.293239*x[1] - 40792.141)
             return fun
-
 
         def c1(x):
             x = np.hstack(([0], x))  # 1-indexed to match reference
@@ -912,8 +914,9 @@ class TestDifferentialEvolutionSolver(object):
                                      constraints=constraints)
         x_opt = (78.0, 33.0, 29.995, 45.0, 36.776)
         f_opt = -30665.5
-        assert_allclose(res.x, x_opt, atol=2)
+        assert_allclose(res.x, x_opt, atol=3)
         assert_allclose(res.fun, f_opt, atol=300)
-        assert_(np.all(np.array(c1(res.x)) >= 0))
+        assert_(np.all(np.array(c1(res.x)) >= np.array([0, 90, 20])))
+        assert_(np.all(np.array(c1(res.x)) <= np.array([92, 110, 25])))
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -799,6 +799,39 @@ class TestDifferentialEvolutionSolver(object):
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))
 
+    def test_L4(self):
+        # Lampinen ([5]) test problem 4
+        def f(x):
+            return np.sum(x[:3])
+
+        A = np.zeros((4, 9))
+        A[1, [4, 6]] = 0.0025, 0.0025
+        A[2, [5, 7, 4]] = 0.0025, 0.0025, -0.0025
+        A[3, [8, 5]] = 0.01, -0.01
+        A = A[1:, 1:]
+        b = np.array([1, 1, 1])
+
+        def c1(x):
+            x = np.hstack(([0], x))  # 1-indexed to match reference
+            return [x[1]*x[6] - 833.33252*x[4] - 100*x[1] + 83333.333,
+                    x[2]*x[7] - 1250*x[5] - x[2]*x[4] + 1250*x[4],
+                    x[3]*x[8] - 1250000 - x[3]*x[5] + 2500*x[5]]
+
+        L = LinearConstraint(A, -np.inf, 1)
+        N = NonlinearConstraint(c1, 0, np.inf)
+        f_opt = 7049.330923
+        bounds = [(100, 10000)] + [(1000, 10000)]*2 + [(10, 1000)]*5
+        constraints = (L, N)
+        res = differential_evolution(f, bounds, maxiter=9000, popsize=30,
+                                     mutation=0.9, recombination=0.9,
+                                     constraints=constraints)
+
+        assert_allclose(res.fun, f_opt, atol=50, rtol=1)
+        assert_(np.all(A @ res.x <= b))
+        assert_(np.all(np.array(c1(res.x)) >= 0))
+        assert_(np.all(res.x >= np.array(bounds)[:, 0]))
+        assert_(np.all(res.x <= np.array(bounds)[:, 1]))
+
     def test_L5(self):
         # Lampinen ([5]) test problem 5
 

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -796,8 +796,9 @@ class TestDifferentialEvolutionSolver(object):
         N = NonlinearConstraint(c1, 0, np.inf)
         bounds = [(-10, 10)]*10
         constraints = (L, N)
-        res = differential_evolution(f, bounds, maxiter=5000, popsize=35, mutation=0.9, recombination=0.9, constraints=constraints)
-        x_opt = (2.171996, 2.363683, 8.773926, 5.095984, 0.990654,
+        res = differential_evolution(f, bounds, maxiter=5000, popsize=35, mutation=0.9,
+                                     recombination=0.9, constraints=constraints)
+        x_opt = (2.171996, 2.363683, 8.773926, 5.095984, 0.9906548,
                  1.430574, 1.321644, 9.828726, 8.280092, 8.375927)
         f_opt = 24.3062091
 

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -706,3 +706,25 @@ class TestDifferentialEvolutionSolver(object):
 
         assert_allclose(res.x, x_opt, atol=1e-1, rtol=1e-1)
         assert_allclose(res.fun, f_opt, atol=3e-2, rtol=3e-2)
+
+        def c1(x):
+            temp = x
+            x = np.zeros(14)
+            x[1:] = temp
+            return [2*x[2] + 2*x[3] + x[11] + x[12],
+                    -8*x[3] + x[12]]
+
+        def c2(x):
+            temp = x
+            x = np.zeros(14)
+            x[1:] = temp
+            return -2*x[8] - x[9] + x[12]
+
+        L = LinearConstraint(A[:5, :], -np.inf, b[:5])
+        L2 = LinearConstraint(A[5:6, :], -np.inf, b[5:6])
+        N = NonlinearConstraint(c1, -np.inf, b[6:8])
+        N2 = NonlinearConstraint(c2, -np.inf, b[8:9])
+        constraints = (L, N, L2, N2)
+        res = differential_evolution(f, bounds, constraints=constraints)
+        assert_allclose(res.x, x_opt, atol=1e-1, rtol=1e-1)
+        assert_allclose(res.fun, f_opt, atol=3e-2, rtol=3e-2)

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -672,9 +672,7 @@ class TestDifferentialEvolutionSolver(object):
         # Lampinen ([5]) test problem 1
 
         def f(x):
-            temp = x
-            x = np.zeros(14)
-            x[1:] = temp  # 1-indexed to match reference
+            x = np.hstack(([0], x))  # 1-indexed to match reference
             fun = np.sum(5*x[1:5]) - 5*x[1:5]@x[1:5] - np.sum(x[5:])
             return fun
 
@@ -708,16 +706,12 @@ class TestDifferentialEvolutionSolver(object):
         assert_allclose(res.fun, f_opt, atol=3e-2, rtol=3e-2)
 
         def c1(x):
-            temp = x
-            x = np.zeros(14)
-            x[1:] = temp
+            x = np.hstack(([0], x))
             return [2*x[2] + 2*x[3] + x[11] + x[12],
                     -8*x[3] + x[12]]
 
         def c2(x):
-            temp = x
-            x = np.zeros(14)
-            x[1:] = temp
+            x = np.hstack(([0], x))
             return -2*x[8] - x[9] + x[12]
 
         L = LinearConstraint(A[:5, :], -np.inf, b[:5])
@@ -726,5 +720,6 @@ class TestDifferentialEvolutionSolver(object):
         N2 = NonlinearConstraint(c2, -np.inf, b[8:9])
         constraints = (L, N, L2, N2)
         res = differential_evolution(f, bounds, constraints=constraints)
+
         assert_allclose(res.x, x_opt, atol=1e-1, rtol=1e-1)
         assert_allclose(res.fun, f_opt, atol=3e-2, rtol=3e-2)

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -885,3 +885,35 @@ class TestDifferentialEvolutionSolver(object):
         assert_(np.all(np.array(c1(res.x)) >= 0))
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))
+
+    def test_L7(self):
+        # Lampinen ([5]) test problem 7
+        def f(x):
+            x = np.hstack(([0], x))  # 1-indexed to match reference
+            fun = (5.3578547*x[3]**2 + 0.8356891*x[1]*x[5] +
+                   37.293239*x[1] - 40792.141)
+            return fun
+
+
+        def c1(x):
+            x = np.hstack(([0], x))  # 1-indexed to match reference
+            return [
+                    85.334407 + 0.0056858*x[2]*x[5] + 0.0006262*x[1]*x[4] - 0.0022053*x[3]*x[5],
+                    80.51249 + 0.0071317*x[2]*x[5] + 0.0029955*x[1]*x[2] + 0.0021813*x[3]**2,
+                    9.300961 + 0.0047026*x[3]*x[5] + 0.0012547*x[1]*x[3] + 0.0019085*x[3]*x[4]
+                    ]
+
+        N = NonlinearConstraint(c1, [0, 90, 20], [92, 110, 25])
+
+        bounds = [(78, 102), (33, 45)]+[(27, 45)]*3
+        constraints = (N)
+        res = differential_evolution(f, bounds, maxiter=2000, popsize=15,
+                                     mutation=0.9, recombination=0.9,
+                                     constraints=constraints)
+        x_opt = (78.0, 33.0, 29.995, 45.0, 36.776)
+        f_opt = -30665.5
+        assert_allclose(res.x, x_opt, atol=2)
+        assert_allclose(res.fun, f_opt, atol=300)
+        assert_(np.all(np.array(c1(res.x)) >= 0))
+        assert_(np.all(res.x >= np.array(bounds)[:, 0]))
+        assert_(np.all(res.x <= np.array(bounds)[:, 1]))

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -859,3 +859,29 @@ class TestDifferentialEvolutionSolver(object):
         assert_(np.all(np.array(c1(res.x)) <= 0))
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))
+
+    def test_L6(self):
+        # Lampinen ([5]) test problem 6
+        def f(x):
+            x = np.hstack(([0], x))  # 1-indexed to match reference
+            fun = (x[1]-10)**3 + (x[2] - 20)**3
+            return fun
+
+        def c1(x):
+            x = np.hstack(([0], x))  # 1-indexed to match reference
+            return [(x[1]-5)**2 + (x[2] - 5)**2 - 100,
+                    -(x[1]-6)**2 - (x[2] - 5)**2 + 82.81]
+
+        N = NonlinearConstraint(c1, 0, np.inf)
+        bounds = [(13, 100), (0, 100)]
+        constraints = (N)
+        res = differential_evolution(f, bounds, maxiter=1000, popsize=15,
+                                     mutation=0.9, recombination=0.9,
+                                     constraints=constraints)
+        x_opt = (14.095, 0.84296)
+        f_opt = -6961.81381
+        assert_allclose(res.x, x_opt, atol=1e-1, rtol=1e-1)
+        assert_allclose(res.fun, f_opt, atol=75, rtol=.01)
+        assert_(np.all(np.array(c1(res.x)) >= 0))
+        assert_(np.all(res.x >= np.array(bounds)[:, 0]))
+        assert_(np.all(res.x <= np.array(bounds)[:, 1]))

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -723,3 +723,36 @@ class TestDifferentialEvolutionSolver(object):
 
         assert_allclose(res.x, x_opt, atol=1e-1, rtol=1e-1)
         assert_allclose(res.fun, f_opt, atol=3e-2, rtol=3e-2)
+
+    def test_L2(self):
+        # Lampinen ([5]) test problem 2
+
+        def f(x):
+            x = np.hstack(([0], x))  # 1-indexed to match reference
+            fun = ((x[1]-10)**2 + 5*(x[2]-12)**2 + x[3]**4 + 3*(x[4]-11)**2 +
+                   10*x[5]**6 + 7*x[6]**2 + x[7]**4 -4*x[6]*x[7] - 10*x[6] -
+                   8*x[7])
+            return fun
+
+        def c1(x):
+            x = np.hstack(([0], x))  # 1-indexed to match reference
+            return [127 - 2*x[1]**2 - 3*x[2]**4 - x[3] - 4*x[4]**2 - 5*x[5],
+                    196 - 23*x[1] - x[2]**2 - 6*x[6]**2 + 8*x[7],
+                    282 - 7*x[1] - 3*x[2] - 10*x[3]**2 - x[4] + x[5],
+                    -4*x[1]**2 - x[2]**2 + 3*x[1]*x[2] - 2*x[3]**2 - 5*x[6] + 11*x[7]]
+
+
+        N = NonlinearConstraint(c1, 0, np.inf)
+        x = (2.330499, 1.951372, -0.4775414, 4.365726,
+             -0.6244870, 1.038131, 1.594227)
+        bounds = [(-10, 10)]*7
+        constraints = (N)
+        res = differential_evolution(f, bounds, maxiter=4000, popsize=20,
+                                     mutation=0.9, recombination=0.9,
+                                     constraints=constraints)
+
+        f_opt = 680.6300599487869
+        assert_allclose(res.fun, f_opt, atol=5, rtol=1e-2)
+        assert_(np.all(np.array(c1(res.x)) >= 0))
+        assert_(np.all(res.x >= np.array(bounds)[:,0]))
+        assert_(np.all(res.x <= np.array(bounds)[:,1]))

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -705,8 +705,8 @@ class TestDifferentialEvolutionSolver(object):
         assert_allclose(res.x, x_opt, atol=1e-1, rtol=1e-1)
         assert_allclose(res.fun, f_opt, atol=3e-2, rtol=3e-2)
         assert_(np.all(A@res.x <= b))
-        assert_(np.all(res.x >= np.array(bounds)[:,0]))
-        assert_(np.all(res.x <= np.array(bounds)[:,1]))
+        assert_(np.all(res.x >= np.array(bounds)[:, 0]))
+        assert_(np.all(res.x <= np.array(bounds)[:, 1]))
 
         def c1(x):
             x = np.hstack(([0], x))
@@ -733,7 +733,7 @@ class TestDifferentialEvolutionSolver(object):
         def f(x):
             x = np.hstack(([0], x))  # 1-indexed to match reference
             fun = ((x[1]-10)**2 + 5*(x[2]-12)**2 + x[3]**4 + 3*(x[4]-11)**2 +
-                   10*x[5]**6 + 7*x[6]**2 + x[7]**4 -4*x[6]*x[7] - 10*x[6] -
+                   10*x[5]**6 + 7*x[6]**2 + x[7]**4 - 4*x[6]*x[7] - 10*x[6] -
                    8*x[7])
             return fun
 
@@ -744,10 +744,7 @@ class TestDifferentialEvolutionSolver(object):
                     282 - 7*x[1] - 3*x[2] - 10*x[3]**2 - x[4] + x[5],
                     -4*x[1]**2 - x[2]**2 + 3*x[1]*x[2] - 2*x[3]**2 - 5*x[6] + 11*x[7]]
 
-
         N = NonlinearConstraint(c1, 0, np.inf)
-        x = (2.330499, 1.951372, -0.4775414, 4.365726,
-             -0.6244870, 1.038131, 1.594227)
         bounds = [(-10, 10)]*7
         constraints = (N)
         res = differential_evolution(f, bounds, maxiter=4000, popsize=20,
@@ -757,5 +754,33 @@ class TestDifferentialEvolutionSolver(object):
         f_opt = 680.6300599487869
         assert_allclose(res.fun, f_opt, atol=5, rtol=1e-2)
         assert_(np.all(np.array(c1(res.x)) >= 0))
-        assert_(np.all(res.x >= np.array(bounds)[:,0]))
-        assert_(np.all(res.x <= np.array(bounds)[:,1]))
+        assert_(np.all(res.x >= np.array(bounds)[:, 0]))
+        assert_(np.all(res.x <= np.array(bounds)[:, 1]))
+
+    def test_L5(self):
+        # Lampinen ([5]) test problem 2
+
+        def f(x):
+            x = np.hstack(([0], x))  # 1-indexed to match reference
+            fun = (np.sin(2*np.pi*x[1])**3*np.sin(2*np.pi*x[2]) /
+                   (x[1]**3*(x[1]*x[2])))
+            return -fun  # maximize
+
+        def c1(x):
+            x = np.hstack(([0], x))  # 1-indexed to match reference
+            return [x[1]**2 - x[2] + 1,
+                    1 - x[1] + (x[2]-4)**2]
+
+        N = NonlinearConstraint(c1, -np.inf, 0)
+        bounds = [(0, 10)]*2
+        constraints = (N)
+        res = differential_evolution(f, bounds, maxiter=500, popsize=20,
+                                     mutation=0.9, recombination=0.9,
+                                     constraints=constraints)
+        x_opt = (1.22067691, 4.24096915)
+        f_opt = -0.10077999749728803
+        assert_allclose(res.x, x_opt, atol=1e-2, rtol=1e-2)
+        assert_allclose(res.fun, f_opt, atol=1e-4, rtol=1e-3)
+        assert_(np.all(np.array(c1(res.x)) <= 0))
+        assert_(np.all(res.x >= np.array(bounds)[:, 0]))
+        assert_(np.all(res.x <= np.array(bounds)[:, 1]))

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -703,6 +703,7 @@ class TestDifferentialEvolutionSolver(object):
         x_opt = (1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 1)
         f_opt = -15
 
+        assert_allclose(f(x_opt), f_opt)
         assert_allclose(res.x, x_opt, atol=1e-1)
         assert_allclose(res.fun, f_opt, atol=0.5)
         assert_(np.all(A@res.x <= b))
@@ -756,6 +757,9 @@ class TestDifferentialEvolutionSolver(object):
                                      constraints=constraints)
 
         f_opt = 680.6300599487869
+        x_opt = (2.330499, 1.951372, -0.4775414, 4.365726, -0.6244870, 1.038131, 1.594227)
+
+        assert_allclose(f(x_opt), f_opt)
         assert_allclose(res.fun, f_opt, atol=5)
         assert_(np.all(np.array(c1(res.x)) >= 0))
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
@@ -796,6 +800,8 @@ class TestDifferentialEvolutionSolver(object):
         x_opt = (2.171996, 2.363683, 8.773926, 5.095984, 0.990654,
                  1.430574, 1.321644, 9.828726, 8.280092, 8.375927)
         f_opt = 24.3062091
+
+        assert_allclose(f(x_opt), f_opt)
         assert_allclose(res.x, x_opt, atol=0.2)
         assert_allclose(res.fun, f_opt, atol=0.5)
         assert_(np.all(A @ res.x >= b))

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -920,3 +920,30 @@ class TestDifferentialEvolutionSolver(object):
         assert_(np.all(np.array(c1(res.x)) <= np.array([92, 110, 25])))
         assert_(np.all(res.x >= np.array(bounds)[:, 0]))
         assert_(np.all(res.x <= np.array(bounds)[:, 1]))
+
+    def test_L9(self):
+        # Lampinen ([5]) test problem 9
+
+        def f(x):
+            x = np.hstack(([0], x))  # 1-indexed to match reference
+            return x[1]**2 + (x[2]-1)**2
+
+        def c1(x):
+            x = np.hstack(([0], x))  # 1-indexed to match reference
+            return [x[2] - x[1]**2]
+
+        N = NonlinearConstraint(c1, [-.001], [0.001])
+
+        bounds = [(-1, 1)]*2
+        constraints = (N)
+        res = differential_evolution(f, bounds, maxiter=1000, popsize=30,
+                                     mutation=0.9, recombination=0.9,
+                                     constraints=constraints)
+        x_opt = [np.sqrt(2)/2, 0.5]
+        f_opt = 0.75
+        assert_allclose(np.abs(res.x), x_opt, atol=0.01)
+        assert_allclose(res.fun, f_opt, atol=0.005)
+        assert_(np.all(np.array(c1(res.x)) >= -0.001))
+        assert_(np.all(np.array(c1(res.x)) <= 0.001))
+        assert_(np.all(res.x >= np.array(bounds)[:, 0]))
+        assert_(np.all(res.x <= np.array(bounds)[:, 1]))

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -704,6 +704,9 @@ class TestDifferentialEvolutionSolver(object):
 
         assert_allclose(res.x, x_opt, atol=1e-1, rtol=1e-1)
         assert_allclose(res.fun, f_opt, atol=3e-2, rtol=3e-2)
+        assert_(np.all(A@res.x <= b))
+        assert_(np.all(res.x >= np.array(bounds)[:,0]))
+        assert_(np.all(res.x <= np.array(bounds)[:,1]))
 
         def c1(x):
             x = np.hstack(([0], x))


### PR DESCRIPTION
_differentialevolution.py reference 5 (Lampinen) reports ten
benchmark problems. This commit adds the first as a test for
differential_evolution with constraints.