### PR TITLE
CI/CD fixes

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -542,7 +542,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     tighten the constraint by a small amount ``eps``:
 
     >>> eps = 0.01
-    ... cons[0]['fun'] = lambda x: x[0] - 2 * x[1] + 2 - eps
+    >>> cons[0]['fun'] = lambda x: x[0] - 2 * x[1] + 2 - eps
 
     we expect the optimal value of the objective function to increase by
     approximately ``eps * res.kkt['ineq'][0]``:
@@ -550,10 +550,10 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     >>> eps * res.kkt['ineq'][0] # Expected change in f0
     array([0.008])
     >>> f0 = res.fun # Keep track of the previous optimal value
-    ... res = minimize(fun, (2, 0), method='SLSQP', bounds=bnds,
+    >>> res = minimize(fun, (2, 0), method='SLSQP', bounds=bnds,
     ...                constraints=cons)
-    ... f1 = res.fun # New optimal value
-    ... f1 - f0
+    >>> f1 = res.fun # New optimal value
+    >>> f1 - f0
     0.008019998807906381
     """
     x0 = np.atleast_1d(np.asarray(x0))

--- a/scipy/optimize/tests/test_slsqp.py
+++ b/scipy/optimize/tests/test_slsqp.py
@@ -81,9 +81,9 @@ def _check_kkt(res, constraints=[], bounds=[], atol=1e-06):
     for mu, g in zip(mus, gs):
         g_eval = np.atleast_1d(g(x))
         # primal feasibility, with a small tolerance for floating point error
-        assert np.all(g_eval >= -1e-14)
+        np.testing.assert_array_less(-1e-12, g_eval)
         # dual feasibility, with a small tolerance for floating point error
-        assert np.all(mu >= -1e-14)
+        np.testing.assert_array_less(-1e-12, mu)
         # complementary slackness
         assert_allclose(g_eval @ mu, 0, atol=atol)
 


### PR DESCRIPTION
Fix the CI/CD failures mentioned in [https://github.com/scipy/scipy/pull/15641#issuecomment-1489241125](https://github.com/scipy/scipy/pull/15641#issuecomment-1489241125).

- Slightly loosen the inequality KKT multiplier tolerances in `_check_kkt`. Previously required `g_eval >= -1e-14`, now require `g_eval > -1e-12`. Theoretically, if a solution satisfies the inequality constraints then they must be non-negative, but in practice sometimes they turn into small negative floats. The tests originally passed locally with the stricter tolerances, but failed on the CI/CD server side test (one multiplier was about `-2e-14`).
- Fix my formatting mistake in the `_minimize` example.