### PR TITLE
remove need for bundled libgfortran in scipy-openblas wheel, fixup

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -152,20 +152,12 @@ jobs:
           echo "CIBW_ENVIRONMENT_MACOS=$CIBW" >> "$GITHUB_ENV"
 
           echo "REPAIR_PATH=$LIB_PATH" >> "$GITHUB_ENV"
-          if [[ ${{ matrix.buildplat[3] }} == 'accelerate' ]]; then
-            PREFIX=DYLD_LIBRARY_PATH=$(dirname $(gfortran --print-file-name libgfortran.dylib))
-          else
-            # Use libgfortran and friends from the scipy-openblas wheel,
-            # which should be exactly the same as the ones from gfortran
-            # This will exclude the duplicates from gfortran in /opt/gfortran*
-            # EXCLUDE="-e /gfortran"
-            
-            PREFIX="DYLD_LIBRARY_PATH=\"\$(python -c \"import scipy_openblas32 as sob; ldir=sob.get_lib_dir();print(f'{ldir}/../.dylibs:{ldir}')\")\""            
-            # remove libgfortran from location used for linking, to check wheel has
-            # bundled things correctly
-            POSTFIX=" sudo rm -rf /opt/gfortran-darwin-x86_64-native &&\
-                     sudo rm -rf /usr/local/gfortran/lib"
-          fi
+          PREFIX=DYLD_LIBRARY_PATH=$(dirname $(gfortran --print-file-name libgfortran.dylib))
+          # remove libgfortran from location used for linking (if any), to
+          # check wheel has bundled things correctly and all tests pass without
+          # needing installed gfortran
+          POSTFIX=" sudo rm -rf /opt/gfortran-darwin-x86_64-native &&\
+                 sudo rm -rf /usr/local/gfortran/lib"
           CIBW="$PREFIX delocate-listdeps -d {wheel} && echo "-----------" &&\
             $PREFIX delocate-wheel -v $EXCLUDE --require-archs \
             {delocate_archs} -w {dest_dir} {wheel} && echo "-----------" &&\

--- a/tools/wheels/cibw_before_build_macos.sh
+++ b/tools/wheels/cibw_before_build_macos.sh
@@ -62,3 +62,11 @@ fi
 # Install Openblas
 python -m pip install -r requirements/openblas.txt
 python -c "import scipy_openblas32; print(scipy_openblas32.get_pkg_config())" > $PROJECT_DIR/scipy-openblas.pc
+
+lib_loc=python -c"import scipy_openblas32; print(scipy_openblas32.get_lib_dir())"
+# Use the libgfortran from gfortran rather than the one in the wheel
+# since delocate gets confused if there is more than one
+# https://github.com/scipy/scipy/issues/20852
+install_name_tool -change @loader_path/../.dylibs/libgfortran.5.dylib @rpath/libgfortran.5.dylib $lib_loc/libsci*
+codesign -s - -f $lib_loc/libsci*
+


### PR DESCRIPTION
I couldn't push directly to your PR. Locally the changes in `tools/wheels/cibw_before_build_macos.sh` solved the delocate problems for me. The codesign call fixes the segfault when using the modified shared object, I hope this works in CI. 

What do you think about simplifying the repair script, I think the `if` clause is redundant now and masked removing the gfortran shared object when using accelerate.